### PR TITLE
Hide old completed tasks in kanban view

### DIFF
--- a/cmd/httpd.go
+++ b/cmd/httpd.go
@@ -214,8 +214,17 @@ func groupTasksByStatus(tasks []internal.Task) map[string][]internal.Task {
 		result[status] = []internal.Task{}
 	}
 
+	now := time.Now()
+	oneDayAgo := now.AddDate(0, 0, -1)
+
 	for _, task := range tasks {
 		status := strings.ToUpper(task.Status)
+
+		// Skip old completed tasks (DONE or WONTDO completed more than 1 day ago)
+		if (status == "DONE" || status == "WONTDO") && task.CompletedAt != nil && task.CompletedAt.Before(oneDayAgo) {
+			continue
+		}
+
 		if _, ok := result[status]; ok {
 			result[status] = append(result[status], task)
 		} else {
@@ -451,6 +460,15 @@ body {
 	display: flex;
 	flex-direction: column;
 	gap: 0.5rem;
+}
+
+.kanban-footer {
+	margin-top: 1rem;
+	padding: 0.5rem;
+	text-align: center;
+	color: var(--text-secondary);
+	font-style: italic;
+	opacity: 0.7;
 }
 
 .kanban-card {

--- a/cmd/httpd_kanban_test.go
+++ b/cmd/httpd_kanban_test.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"taskeru/internal"
+	"testing"
+	"time"
+)
+
+func TestGroupTasksByStatusFiltersOldDoneTasks(t *testing.T) {
+	now := time.Now()
+	twoDaysAgo := now.AddDate(0, 0, -2)
+	fiveHoursAgo := now.Add(-5 * time.Hour)
+
+	tasks := []internal.Task{
+		{
+			ID:     "1",
+			Title:  "Active TODO task",
+			Status: "TODO",
+		},
+		{
+			ID:     "2",
+			Title:  "Currently doing",
+			Status: "DOING",
+		},
+		{
+			ID:          "3",
+			Title:       "Recently completed (5 hours ago)",
+			Status:      "DONE",
+			CompletedAt: &fiveHoursAgo,
+		},
+		{
+			ID:          "4",
+			Title:       "Old completed task (2 days ago)",
+			Status:      "DONE",
+			CompletedAt: &twoDaysAgo,
+		},
+		{
+			ID:          "5",
+			Title:       "Old WONTDO task (2 days ago)",
+			Status:      "WONTDO",
+			CompletedAt: &twoDaysAgo,
+		},
+		{
+			ID:          "6",
+			Title:       "Recent WONTDO (5 hours ago)",
+			Status:      "WONTDO",
+			CompletedAt: &fiveHoursAgo,
+		},
+		{
+			ID:     "7",
+			Title:  "Waiting task",
+			Status: "WAITING",
+		},
+	}
+
+	result := groupTasksByStatus(tasks)
+
+	// Check TODO tasks
+	if len(result["TODO"]) != 1 {
+		t.Errorf("Expected 1 TODO task, got %d", len(result["TODO"]))
+	}
+
+	// Check DOING tasks
+	if len(result["DOING"]) != 1 {
+		t.Errorf("Expected 1 DOING task, got %d", len(result["DOING"]))
+	}
+
+	// Check WAITING tasks
+	if len(result["WAITING"]) != 1 {
+		t.Errorf("Expected 1 WAITING task, got %d", len(result["WAITING"]))
+	}
+
+	// Check DONE tasks - should only have recent one
+	if len(result["DONE"]) != 1 {
+		t.Errorf("Expected 1 DONE task (recent only), got %d", len(result["DONE"]))
+		for _, task := range result["DONE"] {
+			t.Logf("  - %s (completed: %v)", task.Title, task.CompletedAt)
+		}
+	}
+	if len(result["DONE"]) > 0 && result["DONE"][0].Title != "Recently completed (5 hours ago)" {
+		t.Errorf("Expected recent DONE task, got %s", result["DONE"][0].Title)
+	}
+
+	// Check WONTDO tasks - should only have recent one
+	if len(result["WONTDO"]) != 1 {
+		t.Errorf("Expected 1 WONTDO task (recent only), got %d", len(result["WONTDO"]))
+		for _, task := range result["WONTDO"] {
+			t.Logf("  - %s (completed: %v)", task.Title, task.CompletedAt)
+		}
+	}
+	if len(result["WONTDO"]) > 0 && result["WONTDO"][0].Title != "Recent WONTDO (5 hours ago)" {
+		t.Errorf("Expected recent WONTDO task, got %s", result["WONTDO"][0].Title)
+	}
+}
+
+func TestGroupTasksByStatusHandlesNilCompletedAt(t *testing.T) {
+	tasks := []internal.Task{
+		{
+			ID:          "1",
+			Title:       "DONE task without CompletedAt",
+			Status:      "DONE",
+			CompletedAt: nil, // This shouldn't cause a panic
+		},
+		{
+			ID:          "2",
+			Title:       "WONTDO task without CompletedAt",
+			Status:      "WONTDO",
+			CompletedAt: nil, // This shouldn't cause a panic
+		},
+	}
+
+	result := groupTasksByStatus(tasks)
+
+	// Tasks without CompletedAt should be included (they're considered recent)
+	if len(result["DONE"]) != 1 {
+		t.Errorf("Expected 1 DONE task without CompletedAt, got %d", len(result["DONE"]))
+	}
+	if len(result["WONTDO"]) != 1 {
+		t.Errorf("Expected 1 WONTDO task without CompletedAt, got %d", len(result["WONTDO"]))
+	}
+}

--- a/cmd/templates/kanban.html
+++ b/cmd/templates/kanban.html
@@ -34,6 +34,11 @@
                 {{end}}
             </div>
             {{end}}
+            {{if or (eq $status "DONE") (eq $status "WONTDO")}}
+            <div class="kanban-footer">
+                <small>Tasks older than 1 day are hidden</small>
+            </div>
+            {{end}}
         </div>
     </div>
     {{end}}


### PR DESCRIPTION
## Summary
- Automatically hide DONE and WONTDO tasks completed more than 1 day ago in the kanban view
- Add visual indicator to show that old tasks are being filtered
- Make kanban behavior consistent with interactive mode

## Implementation Details

### Filtering Logic
- Tasks with status DONE or WONTDO that have a `CompletedAt` timestamp older than 24 hours are automatically hidden
- Tasks without `CompletedAt` are still shown (considered recent)
- Other statuses (TODO, DOING, WAITING) are not affected

### Visual Indicator
- Added a subtle footer message in DONE and WONTDO columns: "Tasks older than 1 day are hidden"
- Styled with reduced opacity and italic text to be informative but not distracting

### Benefits
- **Reduced clutter**: Keeps the kanban board focused on current work
- **Better performance**: Less DOM elements to render for boards with many completed tasks
- **Consistency**: Matches the behavior of interactive mode which also hides old completed tasks
- **Clean view**: Users can focus on active and recently completed work

## Test plan
- [x] Added comprehensive tests for filtering logic
- [x] Test handles nil CompletedAt without panicking
- [x] Verified correct tasks are shown/hidden based on completion time
- [x] All existing tests pass